### PR TITLE
Update to the latest version of everit-json-schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,6 @@ NB: In Clojure any data is allowed as key in a map. This is not the case in JSON
 
 A future release might allow for a configuration map, setting property attributes such as minimum and maximum values for numbers, length constraints for strings etc.
 
-## deps.edn
-
-If you use `tools.deps` (as opposed to Leiningen), you'll have to copy all dependencies from the Java library manually into `deps.edn`. This is due to [a bug in `tools.deps`](https://dev.clojure.org/jira/browse/TDEPS-46). Refer to [issue #1](https://github.com/luposlip/json-schema/issues/1) for more information.
-
 ## Thanks
 
 To the maintainers of: https://github.com/everit-org/json-schema, on which _validation_ in this Clojure Library is based.

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :repositories {"jitpack" {:url "https://jitpack.io"}}
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [cheshire "5.10.1"]
-                 [com.github.everit-org.json-schema/org.everit.json.schema "1.14.0"]]
+                 [com.github.erosb/everit-json-schema "1.14.1"]]
   :global-vars {*warn-on-reflection* true}
   :repl-options {:init-ns json-schema.core}
   :profiles {:dev {:resource-paths ["test/resources"]}})

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,6 @@
   :url "https://github.com/luposlip/json-schema"
   :license {:name "Apache License, Version 2.0"
             :url "https://www.apache.org/licenses/LICENSE-2.0"}
-  :repositories {"jitpack" {:url "https://jitpack.io"}}
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [cheshire "5.10.1"]
                  [com.github.erosb/everit-json-schema "1.14.1"]]


### PR DESCRIPTION
Would you be open to migrating to the latest version? I was running into some issue trying to depend on this library using vanilla `deps.edn`, due to the fact that `com.github.everit-org.json-schema/org.everit.json.schema "1.14.0"` actually needs to be retrieved from jitpack rather than maven central (I found this out by switching to lein to see if I could get a small evaluation project up an running).

See https://github.com/everit-org/json-schema#maven-installation for
more information